### PR TITLE
s/hostname/Hostname for backwards compatibility

### DIFF
--- a/alerts_consumer.go
+++ b/alerts_consumer.go
@@ -17,7 +17,7 @@ import (
 var lg = logger.New("kinesis-alerts-consumer")
 var sfxSink *sfxclient.HTTPSink
 
-var defaultDimensions = []string{"hostname", "env"}
+var defaultDimensions = []string{"Hostname", "env"}
 
 // AlertsConsumer sends datapoints to SignalFX
 // It implements the kbc.Sender interface
@@ -62,6 +62,12 @@ func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, [
 	}
 	if timestamp.Before(c.minTimestamp) {
 		return []byte{}, []string{}, kbc.ErrMessageIgnored
+	}
+
+	// For backwards compatibility, add `Hostname` field (capitalized)
+	hostname, ok := fields["hostname"]
+	if ok {
+		fields["Hostname"] = hostname
 	}
 
 	// Create datapoints to send to SFX

--- a/alerts_consumer_test.go
+++ b/alerts_consumer_test.go
@@ -35,7 +35,7 @@ func TestProcessMessage(t *testing.T) {
 				"district":    "ddd",
 				"title":       "login_start",
 				"auth_method": "auth",
-				"hostname":    "my-hostname",
+				"Hostname":    "my-hostname",
 				"env":         "test-env",
 			},
 			Value:      datapoint.NewIntValue(1),
@@ -56,7 +56,7 @@ func TestEncodeMessage(t *testing.T) {
 		"value":     float64(123),
 		"dim_a":     "dim_a_val",
 		"dim_b":     "dim_b_val",
-		"hostname":  "my-hostname",
+		"Hostname":  "my-hostname",
 		"env":       "my-env",
 		"timestamp": time.Time{},
 		"_kvmeta": map[string]interface{}{
@@ -84,7 +84,7 @@ func TestEncodeMessage(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewIntValue(123),
@@ -108,7 +108,7 @@ func TestEncodeMessageWithGauge(t *testing.T) {
 		"value":     float64(9.5),
 		"dim_a":     "dim_a_val",
 		"dim_b":     "dim_b_val",
-		"hostname":  "my-hostname",
+		"Hostname":  "my-hostname",
 		"env":       "my-env",
 		"timestamp": time.Time{},
 		"_kvmeta": map[string]interface{}{
@@ -136,7 +136,7 @@ func TestEncodeMessageWithGauge(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -161,7 +161,7 @@ func TestEncodeMessageWithMultipleRoutes(t *testing.T) {
 		"value":     float64(9.5),
 		"dim_a":     "dim_a_val",
 		"dim_b":     "dim_b_val",
-		"hostname":  "my-hostname",
+		"Hostname":  "my-hostname",
 		"env":       "my-env",
 		"timestamp": time.Time{},
 		"_kvmeta": map[string]interface{}{
@@ -197,7 +197,7 @@ func TestEncodeMessageWithMultipleRoutes(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -209,7 +209,7 @@ func TestEncodeMessageWithMultipleRoutes(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -268,7 +268,7 @@ func TestSendBatch(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -279,7 +279,7 @@ func TestSendBatch(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -293,7 +293,7 @@ func TestSendBatch(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -338,7 +338,7 @@ func TestSendBatchWithMultipleEntries(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -349,7 +349,7 @@ func TestSendBatchWithMultipleEntries(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -363,7 +363,7 @@ func TestSendBatchWithMultipleEntries(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -406,7 +406,7 @@ func TestSendBatchResetsTimeForRecentDatapoints(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),
@@ -417,7 +417,7 @@ func TestSendBatchResetsTimeForRecentDatapoints(t *testing.T) {
 			Dimensions: map[string]string{
 				"dim_a":    "dim_a_val",
 				"dim_b":    "dim_b_val",
-				"hostname": "my-hostname",
+				"Hostname": "my-hostname",
 				"env":      "my-env",
 			},
 			Value:      datapoint.NewFloatValue(float64(9.5)),

--- a/global_routes.go
+++ b/global_routes.go
@@ -54,7 +54,7 @@ func processMetricsRoutes(fields map[string]interface{}) []decode.AlertRoute {
 	return []decode.AlertRoute{
 		decode.AlertRoute{
 			Series:     fmt.Sprintf("process-metrics.%s", title),
-			Dimensions: []string{"hostname", "env", "source"},
+			Dimensions: []string{"Hostname", "env", "source"},
 			StatType:   statType,
 			ValueField: defaultValueField,
 			RuleName:   "global-process-metrics",
@@ -84,7 +84,7 @@ func rsyslogRateLimitRoutes(fields map[string]interface{}) []decode.AlertRoute {
 	return []decode.AlertRoute{
 		decode.AlertRoute{
 			Series:     "rsyslog.rate-limit-triggered",
-			Dimensions: []string{"hostname", "env"},
+			Dimensions: []string{"Hostname", "env"},
 			StatType:   statTypeCounter,
 			ValueField: defaultValueField,
 			RuleName:   "global-rsyslog-rate-limit",
@@ -121,7 +121,7 @@ func gearmanRoutes(fields map[string]interface{}) []decode.AlertRoute {
 	return []decode.AlertRoute{
 		decode.AlertRoute{
 			Series:     fmt.Sprintf("gearman.%s", title),
-			Dimensions: []string{"hostname", "function"},
+			Dimensions: []string{"Hostname", "function"},
 			StatType:   statTypeCounter,
 			ValueField: defaultValueField,
 			RuleName:   "global-gearman",
@@ -158,7 +158,7 @@ func gearcmdPassfailRoutes(fields map[string]interface{}) []decode.AlertRoute {
 	return []decode.AlertRoute{
 		decode.AlertRoute{
 			Series:     "gearcmd.passfail",
-			Dimensions: []string{"hostname", "function"},
+			Dimensions: []string{"Hostname", "function"},
 			StatType:   statTypeGauge,
 			ValueField: defaultValueField,
 			RuleName:   "global-gearcmd-passfail",
@@ -187,7 +187,7 @@ func gearcmdDurationRoutes(fields map[string]interface{}) []decode.AlertRoute {
 	return []decode.AlertRoute{
 		decode.AlertRoute{
 			Series:     "gearcmd.duration",
-			Dimensions: []string{"hostname", "function", "env"},
+			Dimensions: []string{"Hostname", "function", "env"},
 			StatType:   statTypeGauge,
 			ValueField: defaultValueField,
 			RuleName:   "global-gearcmd-duration",
@@ -216,7 +216,7 @@ func gearcmdHeartbeatRoutes(fields map[string]interface{}) []decode.AlertRoute {
 	return []decode.AlertRoute{
 		decode.AlertRoute{
 			Series:     "gearcmd.heartbeat",
-			Dimensions: []string{"hostname", "env", "function", "job_id", "try_number", "unit"},
+			Dimensions: []string{"Hostname", "env", "function", "job_id", "try_number", "unit"},
 			StatType:   statTypeGauge,
 			ValueField: defaultValueField,
 			RuleName:   "global-gearcmd-heartbeat",

--- a/global_routes_test.go
+++ b/global_routes_test.go
@@ -26,7 +26,7 @@ func TestProcessMetricsRoutes(t *testing.T) {
 	expected := decode.AlertRoute{
 		Series:     "process-metrics.some-title",
 		StatType:   statTypeCounter,
-		Dimensions: []string{"hostname", "env", "source"},
+		Dimensions: []string{"Hostname", "env", "source"},
 		ValueField: defaultValueField,
 		RuleName:   "global-process-metrics",
 	}
@@ -45,7 +45,7 @@ func TestProcessMetricsRoutes(t *testing.T) {
 	expected = decode.AlertRoute{
 		Series:     "process-metrics.some-title-2",
 		StatType:   statTypeGauge,
-		Dimensions: []string{"hostname", "env", "source"},
+		Dimensions: []string{"Hostname", "env", "source"},
 		ValueField: defaultValueField,
 		RuleName:   "global-process-metrics",
 	}
@@ -68,7 +68,7 @@ func TestRsyslogRateLimitRoutes(t *testing.T) {
 	expected := decode.AlertRoute{
 		Series:     "rsyslog.rate-limit-triggered",
 		StatType:   statTypeCounter,
-		Dimensions: []string{"hostname", "env"},
+		Dimensions: []string{"Hostname", "env"},
 		ValueField: defaultValueField,
 		RuleName:   "global-rsyslog-rate-limit",
 	}
@@ -92,7 +92,7 @@ func TestGearmanRoutes(t *testing.T) {
 	expected := decode.AlertRoute{
 		Series:     "gearman.success",
 		StatType:   statTypeCounter,
-		Dimensions: []string{"hostname", "function"},
+		Dimensions: []string{"Hostname", "function"},
 		ValueField: defaultValueField,
 		RuleName:   "global-gearman",
 	}
@@ -109,7 +109,7 @@ func TestGearmanRoutes(t *testing.T) {
 	expected = decode.AlertRoute{
 		Series:     "gearman.failure",
 		StatType:   statTypeCounter,
-		Dimensions: []string{"hostname", "function"},
+		Dimensions: []string{"Hostname", "function"},
 		ValueField: defaultValueField,
 		RuleName:   "global-gearman",
 	}
@@ -142,7 +142,7 @@ func TestGearcmdPassfailRoutes(t *testing.T) {
 	expected := decode.AlertRoute{
 		Series:     "gearcmd.passfail",
 		StatType:   statTypeGauge,
-		Dimensions: []string{"hostname", "function"},
+		Dimensions: []string{"Hostname", "function"},
 		ValueField: defaultValueField,
 		RuleName:   "global-gearcmd-passfail",
 	}
@@ -174,7 +174,7 @@ func TestGearcmdDurationRoutes(t *testing.T) {
 	expected := decode.AlertRoute{
 		Series:     "gearcmd.duration",
 		StatType:   statTypeGauge,
-		Dimensions: []string{"hostname", "function", "env"},
+		Dimensions: []string{"Hostname", "function", "env"},
 		ValueField: defaultValueField,
 		RuleName:   "global-gearcmd-duration",
 	}
@@ -197,7 +197,7 @@ func TestGearcmdHeartbeatRoutes(t *testing.T) {
 	expected := decode.AlertRoute{
 		Series:     "gearcmd.heartbeat",
 		StatType:   statTypeGauge,
-		Dimensions: []string{"hostname", "env", "function", "job_id", "try_number", "unit"},
+		Dimensions: []string{"Hostname", "env", "function", "job_id", "try_number", "unit"},
 		ValueField: defaultValueField,
 		RuleName:   "global-gearcmd-heartbeat",
 	}


### PR DESCRIPTION
dimension names in SignalFX are case sensitive.
changing from hostname to Hostname caused a discontinuity in many
timeseries.
