### PR TITLE
dimensions: if json input is bool/float, cast to string

### DIFF
--- a/alerts_consumer.go
+++ b/alerts_consumer.go
@@ -93,9 +93,19 @@ func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, [
 		// Look up dimensions (custom + default)
 		dims := map[string]string{}
 		for _, dim := range route.Dimensions {
-			dimVal, ok := fields[dim].(string)
+			dimVal, ok := fields[dim]
 			if ok {
-				dims[dim] = dimVal
+				switch t := dimVal.(type) {
+				case string:
+					dims[dim] = t
+				case float64:
+					// Drop data after the decimal and cast to string (ex. 3.2 => "3")
+					dims[dim] = fmt.Sprintf("%.0f", t)
+				case bool:
+					dims[dim] = fmt.Sprintf("%t", t)
+				default:
+					lg.WarnD("invalid-dimension-value", logger.M{"msg": "Unable to cast dimension value", "dim": dim, "val": dimVal, "route": route.RuleName})
+				}
 			}
 		}
 

--- a/alerts_consumer.go
+++ b/alerts_consumer.go
@@ -104,7 +104,7 @@ func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, [
 				case bool:
 					dims[dim] = fmt.Sprintf("%t", t)
 				default:
-					lg.WarnD("invalid-dimension-value", logger.M{"msg": "Unable to cast dimension value", "dim": dim, "val": dimVal, "route": route.RuleName})
+					return []byte{}, []string{}, fmt.Errorf("error casting dimension value. route=%s dim=%s val=%s", route.RuleName, dim, dimVal)
 				}
 			}
 		}


### PR DESCRIPTION
Previously, we'd fail the type cast and omit the dimension altogether.