### PR TITLE
fix unknown errors; update amazon-kinesis-client-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 1c15021d83a406bc89e9a7a06e02346e9a3d6fb880c109a1536cf2d103b16bb6
-updated: 2017-09-11T20:15:02.040696866Z
+updated: 2017-09-13T19:25:47.64748189Z
 imports:
 - name: github.com/Clever/amazon-kinesis-client-go
-  version: a559c33272e4a6ca153fea95f1c8519dcee664b2
+  version: 32d4d33f00a3672a8cc76af1361ff982ed62d1ad
   subpackages:
   - batchconsumer
   - batchconsumer/stats

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -2,10 +2,10 @@ routes:
   unknown-error-alerts:
     matchers:
       title: ["stats"]
+      unknown-error: [ "*" ]
     output:
       type: "alerts"
       series: "kinesis-consumer.alerts.unknown-error"
       dimensions: [ ]
-      # 0 for ongoing; 1 for failed; -1 for cancelled
       value_field: "unknown-error" 
       stat_type: "counter"

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/signalfx/golib/sfxclient"
 
 	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
-	"github.com/Clever/kayvee-go/logger"
+	"gopkg.in/Clever/kayvee-go.v6/logger"
 )
 
 // getEnv returns required environment variable


### PR DESCRIPTION
only send when `unknown-error` is set. 

also wait for https://github.com/Clever/amazon-kinesis-client-go/pull/16 which makes `unknown-error` to always be set so that we have `0`'s in signalfx