### PR TITLE
Use constructor instead of creating object.

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,10 +55,7 @@ func main() {
 
 	sfxSink := sfxclient.NewHTTPSink()
 	sfxSink.AuthToken = getEnv("SFX_API_TOKEN")
-	ac := &AlertsConsumer{
-		sfxSink:   sfxSink,
-		deployEnv: getEnv("DEPLOY_ENV"),
-	}
+	ac := NewAlertsConsumer(sfxSink, getEnv("DEPLOY_ENV"))
 
 	// Track Max Delay
 	go func() {


### PR DESCRIPTION
This should fix master.  Currently master crashes a soon as it's deployed.  Root cause is a null pointer at https://github.com/Clever/kinesis-alerts-consumer/blob/master/rollups.go#L75