### PR TITLE
Support writing `app_lifecycle` logs to SFX as "events"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -y update && apt-get install -y -q build-essential
 ADD jars jars
 ADD consumer.properties.template .
 ADD run_kcl.sh .
-ADD kinesis-consumer kinesis-consumer
+ADD bin/kinesis-consumer kinesis-consumer
 ADD kvconfig.yml kvconfig.yml
 
 ENTRYPOINT ["/bin/bash", "./run_kcl.sh"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ include golang.mk
 
 APP_NAME := kinesis-alerts-consumer
 SHELL := /bin/bash
+EXECUTABLE = kinesis-consumer
+PKG = github.com/Clever/kinesis-alerts-consumer
 PKGS := $(shell go list ./... | grep -v /vendor )
 .PHONY: download_jars run build
 $(eval $(call golang-version-check,1.9))
@@ -41,10 +43,8 @@ download_jars:
 
 all: test build
 
-
-
 build:
-	CGO_ENABLED=0 go build -a -installsuffix cgo -o kinesis-consumer
+	$(call golang-build,$(PKG),$(EXECUTABLE))
 
 docker_build: download_jars
 	GOOS=linux GOARCH=amd64 make build

--- a/global_routes_test.go
+++ b/global_routes_test.go
@@ -226,3 +226,25 @@ func TestWagCircuitBreakerRoutes(t *testing.T) {
 	}
 	assert.Equal(t, expected, routes[0])
 }
+
+func TestAppLifecycleRoutes(t *testing.T) {
+	t.Log("Base case: doesn't route empty log")
+	fields := map[string]interface{}{}
+	routes := appLifecycleRoutes(fields)
+	assert.Equal(t, 0, len(routes))
+
+	t.Log("Routes a log")
+	fields = map[string]interface{}{
+		"category": "app_lifecycle",
+		"title":    "app_deploying",
+	}
+	routes = appLifecycleRoutes(fields)
+	assert.Equal(t, 1, len(routes))
+	expected := decode.AlertRoute{
+		Series:     "app_lifecycle",
+		StatType:   statTypeEvent,
+		Dimensions: []string{"container_app", "container_env", "launched_scope", "title", "user", "version", "team"},
+		RuleName:   "global-app-lifecycle",
+	}
+	assert.Equal(t, expected, routes[0])
+}

--- a/rollups_test.go
+++ b/rollups_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type ByMetric []datapoint.Datapoint
+type ByMetric []*datapoint.Datapoint
 
 func (m ByMetric) Len() int           { return len(m) }
 func (m ByMetric) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 func (m ByMetric) Less(i, j int) bool { return m[i].Metric < m[j].Metric }
 
 func TestRollupRequestFinished(t *testing.T) {
-	mockSink := &MockSink{}
+	mockSink := &MockHTTPSink{}
 	r := NewRollups(mockSink)
 	r.scheduler.ReportingDelayNs = (1 * time.Second).Nanoseconds()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -38,15 +38,15 @@ func TestRollupRequestFinished(t *testing.T) {
 
 	time.Sleep(1*time.Second + 100*time.Millisecond)
 
-	expectedPts := []datapoint.Datapoint{
-		datapoint.Datapoint{Metric: "request-finished-response-time.count",
+	expectedPts := []*datapoint.Datapoint{
+		&datapoint.Datapoint{Metric: "request-finished-response-time.count",
 			Dimensions: map[string]string{"env": "production", "container_app": "app-service", "canary": "false"},
 			Value:      datapoint.NewIntValue(100),
 			MetricType: datapoint.Counter,
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-response-time.sum",
 			Dimensions: map[string]string{"env": "production", "container_app": "app-service", "canary": "false"},
 			Value:      datapoint.NewFloatValue(100000000),
@@ -54,7 +54,7 @@ func TestRollupRequestFinished(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-response-time.sumsquare",
 			Dimensions: map[string]string{"env": "production", "container_app": "app-service", "canary": "false"},
 			Value:      datapoint.NewFloatValue(100000000000000),
@@ -62,7 +62,7 @@ func TestRollupRequestFinished(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-status-code.count",
 			Dimensions: map[string]string{"env": "production", "container_app": "app-service", "canary": "false", "status-code": "200"},
 			Value:      datapoint.NewIntValue(100),
@@ -70,7 +70,7 @@ func TestRollupRequestFinished(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-status-code.sum",
 			Dimensions: map[string]string{"env": "production", "container_app": "app-service", "canary": "false", "status-code": "200"},
 			Value:      datapoint.NewIntValue(100),
@@ -78,7 +78,7 @@ func TestRollupRequestFinished(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-status-code.sumsquare",
 			Dimensions: map[string]string{"env": "production", "container_app": "app-service", "canary": "false", "status-code": "200"},
 			Value:      datapoint.NewFloatValue(100),
@@ -101,7 +101,7 @@ func TestRollupRequestFinished(t *testing.T) {
 }
 
 func TestRollupRequestFinishedThrift(t *testing.T) {
-	mockSink := &MockSink{}
+	mockSink := &MockHTTPSink{}
 	r := NewRollups(mockSink)
 	r.scheduler.ReportingDelayNs = (1 * time.Second).Nanoseconds()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -120,15 +120,15 @@ func TestRollupRequestFinishedThrift(t *testing.T) {
 
 	time.Sleep(1*time.Second + 100*time.Millisecond)
 
-	expectedPts := []datapoint.Datapoint{
-		datapoint.Datapoint{Metric: "request-finished-response-time.count",
+	expectedPts := []*datapoint.Datapoint{
+		&datapoint.Datapoint{Metric: "request-finished-response-time.count",
 			Dimensions: map[string]string{"env": "production", "container_app": "systemic"},
 			Value:      datapoint.NewIntValue(100),
 			MetricType: datapoint.Counter,
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-response-time.sum",
 			Dimensions: map[string]string{"env": "production", "container_app": "systemic"},
 			Value:      datapoint.NewFloatValue(100000000),
@@ -136,7 +136,7 @@ func TestRollupRequestFinishedThrift(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-response-time.sumsquare",
 			Dimensions: map[string]string{"env": "production", "container_app": "systemic"},
 			Value:      datapoint.NewFloatValue(100000000000000),
@@ -144,7 +144,7 @@ func TestRollupRequestFinishedThrift(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-type-id.count",
 			Dimensions: map[string]string{"env": "production", "container_app": "systemic", "type_id": "2"},
 			Value:      datapoint.NewIntValue(100),
@@ -152,7 +152,7 @@ func TestRollupRequestFinishedThrift(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-type-id.sum",
 			Dimensions: map[string]string{"env": "production", "container_app": "systemic", "type_id": "2"},
 			Value:      datapoint.NewIntValue(100),
@@ -160,7 +160,7 @@ func TestRollupRequestFinishedThrift(t *testing.T) {
 			Timestamp:  time.Time{},
 			Meta:       map[interface{}]interface{}{},
 		},
-		datapoint.Datapoint{
+		&datapoint.Datapoint{
 			Metric:     "request-finished-type-id.sumsquare",
 			Dimensions: map[string]string{"env": "production", "container_app": "systemic", "type_id": "2"},
 			Value:      datapoint.NewFloatValue(100),


### PR DESCRIPTION
Previously, we only sent datapoints (gauges, counters) to SFX. SFX also
supports user sent events, such as deployment events. We're trying this
out by sending just app_lifecycle events directly from this consumer.

We may someday expand this pattern to allow users to route events from
Kayvee routing, but for now this is not supported.

--

Implementation approach:

1. add a global route that matches app_lifecycle logs
2. when matching one of these, emit a metric with `statType = "event"`
3. change batching logic to handle a mixture of datapoints and events
4. submit events via SFX Client's `AddEvents` method.