### PR TITLE
removing 'Hostname' and 'env' as default dimensions for cloudwatch

### DIFF
--- a/alerts_consumer_test.go
+++ b/alerts_consumer_test.go
@@ -92,7 +92,7 @@ func TestProcessMessageSupportsCloudwatch(t *testing.T) {
 	consumer := AlertsConsumer{
 		deployEnv: "test-env",
 	}
-	rawmsg := `2017-08-15T18:39:07.000000+00:00 my-hostname production--my-app/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2Fbe5eafc1-8e44-489a-8942-aaaaaaaaaaaa[3337]: {"_kvmeta":{"kv_language":"go","kv_version":"6.16.0","routes":[{"dimensions":["cloudwatch-namespace"],"rule":"unexpected-stop","series":"ContainerExitCount","stat_type":"counter","type":"alerts","value_field":"value"}],"team":"eng-infra"},"category":"app_lifecycle","level":"info","title":"title","region":"reg","type":"counter","value":1}`
+	rawmsg := `2017-08-15T18:39:07.000000+00:00 my-hostname production--my-app/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2Fbe5eafc1-8e44-489a-8942-aaaaaaaaaaaa[3337]: {"_kvmeta":{"kv_language":"go","kv_version":"6.16.0","routes":[{"dimensions":["dimension1"],"rule":"unexpected-stop","series":"ContainerExitCount","stat_type":"counter","type":"alerts","value_field":"value"}],"team":"eng-infra"},"category":"app_lifecycle","level":"info","title":"title","dimension1":"dim","region":"reg","type":"counter","value":1}`
 	msg, tags, err := consumer.ProcessMessage([]byte(rawmsg))
 	assert.NoError(t, err)
 
@@ -111,8 +111,9 @@ func TestProcessMessageSupportsCloudwatch(t *testing.T) {
 			&datapoint.Datapoint{
 				Metric: "ContainerExitCount",
 				Dimensions: map[string]string{
-					"Hostname": "my-hostname",
-					"env":      "test-env",
+					"Hostname":   "my-hostname",
+					"env":        "test-env",
+					"dimension1": "dim",
 				},
 				Value:      datapoint.NewIntValue(1),
 				MetricType: datapoint.Counter,
@@ -124,12 +125,8 @@ func TestProcessMessageSupportsCloudwatch(t *testing.T) {
 			&cloudwatch.MetricDatum{
 				Dimensions: []*cloudwatch.Dimension{
 					&cloudwatch.Dimension{
-						Name:  aws.String("Hostname"),
-						Value: aws.String("my-hostname"),
-					},
-					&cloudwatch.Dimension{
-						Name:  aws.String("env"),
-						Value: aws.String("test-env"),
+						Name:  aws.String("dimension1"),
+						Value: aws.String("dim"),
 					},
 				},
 				MetricName:        aws.String("ContainerExitCount"),


### PR DESCRIPTION
These dimensions (specifically Hostname) make it difficult to do queries, since I don't see how it would be known in advance.

This seems like the least intrusive way to change things, but it's also not clear to me that we need these as dimensions in SignalFX.

examples from Cloudwatch of the current metrics for ContainerExitCount:
<img width="1123" alt="Screen Shot 2019-08-19 at 10 58 14 AM" src="https://user-images.githubusercontent.com/50673502/63287982-736a9000-c270-11e9-9741-724738409bb7.png">
<img width="1121" alt="Screen Shot 2019-08-19 at 10 58 01 AM" src="https://user-images.githubusercontent.com/50673502/63287983-736a9000-c270-11e9-8ead-1b0416a97710.png">
