### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* nathan.leiby@clever.com
+* @Clever/eng-infra


### PR DESCRIPTION
This is required to get auto assignment when opening a PR, which will be more important now that I've turned on dependabot for this repo.