### PR TITLE
send log volume info to SFX

### DIFF
--- a/alerts_consumer.go
+++ b/alerts_consumer.go
@@ -83,6 +83,10 @@ func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, [
 	// Determine routes
 	// KVMeta Routes
 	kvmeta := decode.ExtractKVMeta(fields)
+	env, _ := fields["container_env"].(string)
+	app, _ := fields["container_app"].(string)
+	updatelogVolumes(env, app, kvmeta.Team)
+
 	routes := kvmeta.Routes.AlertRoutes()
 	for idx := range routes {
 		routes[idx].Dimensions = append(routes[idx].Dimensions, sfxDefaultDimensions...)

--- a/kvconfig.yml
+++ b/kvconfig.yml
@@ -9,6 +9,15 @@ routes:
       dimensions: [ ]
       value_field: "unknown-error" 
       stat_type: "counter"
+  log-volume-send-failure:
+    matchers:
+      title: ["failed-sending-volumes"]
+    output:
+      type: "notifications"
+      channel: "#eng-infra-alerts-minor"
+      icon: ":signalfx:"
+      user: "kinesis-alerts-consumer"
+      message: "Error sending log volumes: ```%{error}```"
   cloudwatch-errors:
     matchers:
       title: ["error-sending-to-cloudwatch"]

--- a/main.go
+++ b/main.go
@@ -77,6 +77,14 @@ func main() {
 		}
 	}()
 
+	// Track Volume
+	go func() {
+		c := time.Tick(time.Minute)
+		for _ = range c {
+			logVolumesAndReset(sfxSink)
+		}
+	}()
+
 	consumer := kbc.NewBatchConsumer(config, ac)
 	consumer.Start()
 }

--- a/volume.go
+++ b/volume.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/eapache/go-resiliency/retrier"
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/golib/sfxclient"
+	"golang.org/x/net/context"
+
+	"gopkg.in/Clever/kayvee-go.v6/logger"
+)
+
+type envAppTeam struct {
+	env  string
+	app  string
+	team string
+}
+
+var logVolumesByEnvAppTeam = map[envAppTeam]int64{}
+var logVolumesLock = sync.Mutex{}
+var retry = retrier.New(retrier.ExponentialBackoff(5, 50*time.Millisecond), nil)
+
+func updatelogVolumes(env, app, team string) {
+	if env == "" {
+		env = "unknown"
+	}
+	if app == "" {
+		app = "unknown"
+	}
+	if team == "" {
+		team = "unknown"
+	}
+	logVolumesLock.Lock()
+	defer logVolumesLock.Unlock()
+	logVolumesByEnvAppTeam[envAppTeam{
+		env:  env,
+		app:  app,
+		team: team,
+	}] += 1
+}
+
+func logVolumesAndReset(sfx *sfxclient.HTTPSink) {
+	logVolumesCopy := logVolumesByEnvAppTeam
+	logVolumesLock.Lock()
+	logVolumesByEnvAppTeam = map[envAppTeam]int64{}
+	logVolumesLock.Unlock()
+
+	var dps []*datapoint.Datapoint
+	var totalCount int64
+	for eat, count := range logVolumesCopy {
+		dps = append(dps, sfxclient.Cumulative("kinesis-consumer.log-volume", map[string]string{
+			"env":         eat.env,
+			"application": eat.app,
+			"team":        eat.team,
+		}, count))
+		totalCount += count
+	}
+	err := retry.Run(func() error {
+		lg.TraceD("send-log-volumes", logger.M{"total-logs": totalCount, "point-count": len(dps)})
+		return sfx.AddDatapoints(context.Background(), dps)
+	})
+	if err != nil {
+		lg.ErrorD("failed-sending-volumes", logger.M{"total-logs": totalCount, "error": err.Error()})
+	}
+}


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRANG-4225

It would be nice to be able to track total log volume, and volume by env/app or team.

Can't think of a great way to test this in advance, but fortunately it shouldn't cause any problems, and I can just check in SignalFX that data is eventually coming in.

Also adding log-routing to Slack so that we are aware if data isn't coming through properly