### PR TITLE
use either 'team' or 'kv_team'

### DIFF
--- a/alerts_consumer.go
+++ b/alerts_consumer.go
@@ -85,7 +85,11 @@ func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, [
 	kvmeta := decode.ExtractKVMeta(fields)
 	env, _ := fields["container_env"].(string)
 	app, _ := fields["container_app"].(string)
-	updatelogVolumes(env, app, kvmeta.Team)
+	team, _ := fields["team"].(string)
+	if team == "" {
+		team = kvmeta.Team
+	}
+	updatelogVolumes(env, app, team)
 
 	routes := kvmeta.Routes.AlertRoutes()
 	for idx := range routes {


### PR DESCRIPTION
I noticed that sometimes `team` is set and sometimes `kv_team` is set, but sometimes one and not the other.

`team` but not `kvMeta.team`: [link](https://production--haproxy-logs.int.clever.com/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-10m,to:now))&_a=(columns:!(title),index:'78e8dcb0-fff4-11e8-819f-3dbcf12e7319',interval:auto,query:(language:lucene,query:'_exists_:team%20AND%20!!_exists_:kv_team'),sort:!(!(timestamp,desc)))) This makes sense, since `kvMeta.team` should only have a value if there is a log-routing route

`kvMeta.team` but not `team`: [link](https://production--haproxy-logs.int.clever.com/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-10m,to:now))&_a=(columns:!(title),index:'78e8dcb0-fff4-11e8-819f-3dbcf12e7319',interval:auto,query:(language:lucene,query:'!!_exists_:team%20AND%20_exists_:kv_team'),sort:!(!(timestamp,desc)))) Honestly not sure why this would ever happen. It would definitely be better to fix the underlying reason for this, but I looked into it for a while and couldn't figure it out, so figured this was at least an improvement for now