### PR TITLE
track total bytes of logs

### DIFF
--- a/alerts_consumer.go
+++ b/alerts_consumer.go
@@ -60,7 +60,7 @@ func (c *AlertsConsumer) ProcessMessage(rawmsg []byte) (msg []byte, tags []strin
 		return nil, []string{}, err
 	}
 
-	return c.encodeMessage(fields)
+	return c.encodeMessage(fields, len(rawmsg))
 }
 
 type EncodeOutput struct {
@@ -79,7 +79,7 @@ func contains(slice []string, s string) bool {
 	return false
 }
 
-func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, []string, error) {
+func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}, numBytes int) ([]byte, []string, error) {
 	// Determine routes
 	// KVMeta Routes
 	kvmeta := decode.ExtractKVMeta(fields)
@@ -89,7 +89,7 @@ func (c *AlertsConsumer) encodeMessage(fields map[string]interface{}) ([]byte, [
 	if team == "" {
 		team = kvmeta.Team
 	}
-	updatelogVolumes(env, app, team)
+	updatelogVolumes(env, app, team, numBytes)
 
 	routes := kvmeta.Routes.AlertRoutes()
 	for idx := range routes {

--- a/alerts_consumer_test.go
+++ b/alerts_consumer_test.go
@@ -166,7 +166,7 @@ func TestEncodeMessage(t *testing.T) {
 		},
 	}
 
-	output, tags, err := consumer.encodeMessage(input)
+	output, tags, err := consumer.encodeMessage(input, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(tags))
 	assert.Equal(t, string("default"), tags[0])
@@ -219,7 +219,7 @@ func TestEncodeMessageWithNonStringDimensions(t *testing.T) {
 		},
 	}
 
-	output, tags, err := consumer.encodeMessage(input)
+	output, tags, err := consumer.encodeMessage(input, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(tags))
 	assert.Equal(t, string("default"), tags[0])
@@ -271,7 +271,7 @@ func TestEncodeMessageErrorsIfInvalidDimensionType(t *testing.T) {
 		},
 	}
 
-	_, _, err := consumer.encodeMessage(input)
+	_, _, err := consumer.encodeMessage(input, 0)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "error casting dimension value. rule=rule-1 dim=dim_error val={}")
 }
@@ -299,7 +299,7 @@ func TestEncodeMessageErrorsIfValueExistsAndIsInvalidType(t *testing.T) {
 		},
 	}
 
-	_, _, err := consumer.encodeMessage(input)
+	_, _, err := consumer.encodeMessage(input, 0)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "value exists but is wrong type. rule=rule-1 value_field=value value=12345")
 }
@@ -329,7 +329,7 @@ func TestEncodeMessageWithGauge(t *testing.T) {
 		},
 	}
 
-	output, tags, err := consumer.encodeMessage(input)
+	output, tags, err := consumer.encodeMessage(input, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(tags))
 	assert.Equal(t, string("default"), tags[0])
@@ -390,7 +390,7 @@ func TestEncodeMessageWithMultipleRoutes(t *testing.T) {
 		},
 	}
 
-	output, tags, err := consumer.encodeMessage(input)
+	output, tags, err := consumer.encodeMessage(input, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(tags))
 	assert.Equal(t, string("default"), tags[0])
@@ -449,7 +449,7 @@ func TestEncodeMessageWithNoAlertsRoutes(t *testing.T) {
 			},
 		},
 	}
-	_, _, err := consumer.encodeMessage(input)
+	_, _, err := consumer.encodeMessage(input, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "intentionally skipped")
 }


### PR DESCRIPTION
We don't really have a great mechanism for tracking how many bytes apps are writing since the kinesis stream contains compressed data, and the ES cluster probably inflated data (and only limited to what we didn't sample out).

I'm planning to add something similar to the log-dropping metrics we make here https://github.com/Clever/kinesis-eslogs-consumer/blob/master/sender/stats/stats.go

I'd also love a sanity-check that this should give the number that we'd actually want.