### PR TITLE
migrate to noHomepod

### DIFF
--- a/launch/kinesis-alerts-consumer.yml
+++ b/launch/kinesis-alerts-consumer.yml
@@ -26,8 +26,4 @@ aws:
     - CloudWatchMetricsWriter
     - KinesisLogsConsumer
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-1
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
Migrate workers to noHomepod. `ark scale` is fixed and for the relevant workers, they are scaled to the previous value
