### PR TITLE
adjust scale to match current scale

### DIFF
--- a/launch/kinesis-alerts-consumer.yml
+++ b/launch/kinesis-alerts-consumer.yml
@@ -12,6 +12,9 @@ env:
 resources:
   cpu: 4
   max_mem: 8
+autoscaling:
+  min_count: 20
+  max_count: 20
 shepherds:
 - nathan.leiby@clever.com
 expose: []


### PR DESCRIPTION
**Jira:** 
https://clever.atlassian.net/browse/INFRANG-4911

**Overview:**
https://github.com/Clever/catapult/pull/1790 this PR is going to change how deployment are handled for applications after scaling. Today we have a complicated logic which tries to honor the count set by a scale override for apps that are not autoscaled. This logic is hard for infra engineers to remember and prone to bugs.

Because we are not honoring scale anymore, this PR was created to set count = what is currently deployed so that the app doesn't default back to 2. If you think this is not required for your app and the default is fine then feel free to close this PR. Also consider if this app needs autoscaling!
