### PR TITLE
Upgrade CircleCI to use contexts for OIDC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/go/src/github.com/Clever/kinesis-alerts-consumer
@@ -34,3 +34,8 @@ jobs:
     - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
     - run: $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/dapple-deploy $DAPPLE_URL $DAPPLE_USER $DAPPLE_PASS $APP_NAME; fi;
+workflows:
+  build_test_publish_deploy:
+    jobs:
+    - build:
+        context: aws-ecr-public


### PR DESCRIPTION
This upgrades CircleCI config yamls to use 
`context: aws*` definitions. See https://clever.slack.com/archives/C063L91T7/p1695056411674719 for the announcement.
If the CI checks are green, it means it is working. 