### PR TITLE
remove mesh_config

### DIFF
--- a/launch/kinesis-alerts-consumer-us-west-2.yml
+++ b/launch/kinesis-alerts-consumer-us-west-2.yml
@@ -40,8 +40,3 @@ telemetry:
   metrics:
     exporters:
     - datadog
-mesh_config:
-  dev:
-    state: mesh_only
-  prod:
-    state: mesh_only

--- a/launch/kinesis-alerts-consumer.yml
+++ b/launch/kinesis-alerts-consumer.yml
@@ -43,8 +43,3 @@ telemetry:
   metrics:
     exporters:
     - datadog
-mesh_config:
-  dev:
-    state: mesh_only
-  prod:
-    state: mesh_only


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6012

# Overview
Delete the mesh config as we are exiting mesh and this mesh_config is not used anymore.

# Testing
Currently catapult is using a feature flag in place of this mesh config and the feature flag is set to "alb_only" for this app. Which means this is already running in production

# Rollout
Merge PR and deploy via dapple
